### PR TITLE
some more experiments

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,19 @@
 # Switch Java version
-export JAVA_HOME=`/usr/libexec/java_home -v 21`
+`export JAVA_HOME=`/usr/libexec/java_home -v 21``
 
 # Howto Run
 
 ## Run flagd as a docker container
-docker run -p 8013:8013 -v $(pwd)/:/etc/flagd/ -it ghcr.io/open-feature/flagd:latest start --uri file:/etc/flagd/flags.json
+`docker run -p 8013:8013 -v $(pwd)/:/etc/flagd/ -it ghcr.io/open-feature/flagd:latest start --uri file:/etc/flagd/flags.json`
 
 ## compile
-mvn clean install
+`mvn clean install`
 
 ## Run the application
-java -jar target/openfeature-demo-0.0.1-SNAPSHOT.jar
+`java -jar target/openfeature-demo-0.0.1-SNAPSHOT.jar`
 
 ## Tests
+```
 curl -X GET  http://localhost:8080/hello 
 Hello!
 curl -X GET  http://localhost:8080/retries
@@ -21,13 +22,18 @@ curl -X GET http://localhost:8080/isColorYellow
 Feature enabled: false
 curl -X GET http://localhost:8080/isNewFeatureEnabled
 Feature enabled: false
-
+curl -X GET http://localhost:8080/isSpecialFeatureEnabled -H "Authentication: 59333-0006"
+Feature enabled: true
+curl -X GET http://localhost:8080/isSpecialFeatureEnabled -H "Authentication: 59333-0007"
+Feature enabled: false
+```
 
 ## Change flag to on
-1st Call: "defaultVariant": "on"
-2nd Call: "defaultVariant": "high"
+- 1st Call: "defaultVariant": "on"
+- 2nd Call: "defaultVariant": "high"
 
 ## Test again...
+```
 curl -X GET http://localhost:8080/hello
 Hello, welcome to this OpenFeature-enabled website!
 curl -X GET http://localhost:8080/retries
@@ -36,5 +42,6 @@ curl -X GET "http://localhost:8080/isColorYellow?color=yellow"
 Feature enabled: true
 curl -X GET http://localhost:8080/isNewFeatureEnabled -H "group: Mitarbeiter"
 Feature enabled: true
+```
 
 

--- a/flags.json
+++ b/flags.json
@@ -78,7 +78,31 @@
           "off"
         ]
       }
-    }
+    },
+    "special-feature": {
+      "state": "ENABLED",
+      "defaultVariant": "false",
+      "variants": {
+        "true": true,
+        "false": false
+      },
+      "targeting": {
+        "if": [
+          {
+            "in": [
+              {
+                "var": "contract"
+              },
+              [
+                "59333-0006",
+                "59444-0006"
+              ]
+            ]
+          },
+          "true"
+        ]
+      }
+    }    
   }
 }
 

--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,12 @@
 		<java.version>21</java.version>
 	</properties>
 	<dependencies>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-actuator</artifactId>
+		</dependency>
+
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>

--- a/src/main/java/com/openfeature_demo/RaiContext.java
+++ b/src/main/java/com/openfeature_demo/RaiContext.java
@@ -1,0 +1,20 @@
+package com.openfeature_demo;
+
+import java.util.Optional;
+
+import dev.openfeature.sdk.MutableContext;
+
+public class RaiContext extends MutableContext{
+
+    public RaiContext(String contractNr){
+        String contract = Optional.ofNullable(contractNr).orElse("");
+        super.add("contract", contract);
+    }
+
+    public RaiContext(Object token){
+        // super.add("contract", token.getContractNr);
+        // super.add("bu", token.getBu);
+        // ...
+    }
+
+}

--- a/src/main/java/com/openfeature_demo/TestAPI.java
+++ b/src/main/java/com/openfeature_demo/TestAPI.java
@@ -7,9 +7,6 @@ import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Set;
 
 @RestController
 public class TestAPI {
@@ -66,6 +63,18 @@ public class TestAPI {
         MutableContext context = new MutableContext();
         context.add("group", group);
         boolean feature = client.getBooleanValue("newFeature", false, context);
+        return "Feature enabled: " + feature;
+
+    }
+
+
+    @GetMapping("/isSpecialFeatureEnabled")
+    public String isSpecialFeatureEnabled(@RequestHeader(value = "Authentication") String contract) {
+        final Client client = openFeatureAPI.getClient();
+
+        // Create a context with the user token....
+        MutableContext context = new RaiContext(contract);
+        boolean feature = client.getBooleanValue("special-feature", false, context);
         return "Feature enabled: " + feature;
 
     }


### PR DESCRIPTION
- add a RaiContext to show how to simplify context creation based on a token
- adds a new feature which is enabled for single contracts only